### PR TITLE
Google plus is dead 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,7 @@
 
 This is the batch conversion of my Image Collection that i use to create brushpacks. The images are saved with a brush spacing of 1; folder and file names are the same as in the image collection – so you can work with both formats if you want, and easily find corresponding files.
 
-Image-Galleries:
-
-- [Aqua](https://plus.google.com/photos/106923723656618758734/albums/5956474937579468881)
-- [Dots](https://plus.google.com/photos/106923723656618758734/albums/5949778455253717233)
-- [Fibers](https://plus.google.com/photos/106923723656618758734/albums/5949779849791017809)
-- [Fuzzy](https://plus.google.com/photos/106923723656618758734/albums/5949781600486048257)
-- [Grain](https://plus.google.com/photos/106923723656618758734/albums/5949782332669889857)
-- [Opaque](https://plus.google.com/photos/106923723656618758734/albums/5949783172726857793)
-- [Organic](https://plus.google.com/photos/106923723656618758734/albums/5949784111306075825)
-- [Shapes](https://plus.google.com/photos/106923723656618758734/albums/5949784832086657473)
-- [Spiky](https://plus.google.com/photos/106923723656618758734/albums/5949787596636518081)
-- [Spot](https://plus.google.com/photos/106923723656618758734/albums/5949787941206066033)
-- [Strokes Thick](https://plus.google.com/photos/106923723656618758734/albums/5949789536239595777)
-- [Strokes Thin](https://plus.google.com/photos/106923723656618758734/albums/5949792891532680897)
+~~Image-Galleries~~ (Gone due Google Plus being dead)
 
 Note: This is a "raw" resource (not adjusted or proofed) meant to help people creating their own custom brushes or brushpacks and share their work if they want without thinking about license restrictrictions. 
 


### PR DESCRIPTION
Google plus is dead - those links can be removed because they also don't work.